### PR TITLE
Add Julia capture orbit backend

### DIFF
--- a/.github/workflows/asteroid-data.yml
+++ b/.github/workflows/asteroid-data.yml
@@ -32,8 +32,13 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1.12"
       - name: Install
         run: python -m pip install -e ".[dev]"
+      - name: Test Julia backend
+        run: julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'
       - name: Test
         run: pytest
       - name: Lint maintained modules
@@ -65,8 +70,13 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1.12"
       - name: Install runtime
         run: python -m pip install -e .
+      - name: Install Julia backend dependencies
+        run: julia --project=. -e 'using Pkg; Pkg.instantiate()'
       - name: Fetch, plan, and persist
         run: python -m app.ingest --print-json
       - name: Verify SQLite integrity

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 *.pyo
 
 # local artifacts / backups
+.local/
 app/viewer3d.backup.pydata/**/*.json
 *.bsp
 .venv/

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,100 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.6"
+manifest_format = "2.0"
+project_hash = "fd9c0f96664e61338abffc7d8fc7e1e853953315"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.AsteroidPlannerBackend]]
+deps = ["JSON", "LinearAlgebra"]
+path = "."
+uuid = "9e7a3fb7-5164-4f24-a86d-ff68a3122b62"
+version = "0.1.0"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.4"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.12.0"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.29+0"
+
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "32a4e09c5f29402573d673901778a0e03b0807b9"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.8.6"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.4"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.15.0+0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,17 @@
+name = "AsteroidPlannerBackend"
+uuid = "9e7a3fb7-5164-4f24-a86d-ff68a3122b62"
+version = "0.1.0"
+
+[deps]
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[compat]
+JSON = "0.21"
+julia = "1.12"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The project combines live [JPL Small-Body Database](https://ssd-api.jpl.nasa.gov
 - Searches configurable departure and arrival grids.
 - Solves the heliocentric, single-revolution Lambert problem.
 - Rejects solutions that fail an endpoint propagation check.
+- Estimates asteroid capture burn and a bounded final orbit with a Julia density-sphere model.
 - Stores encounters, elements, ingestion history, and transfer plans in SQLite.
 - Presents the catalog and read-only SQL tools inside the desktop application.
 - Retains a responsive Flask dashboard, CSV export, and JSON API as a browser fallback.
@@ -104,6 +105,7 @@ Operational defaults are listed below; `.env.example` documents every supported 
 | `INTERCEPT_TOF_STEP_DAYS` | `10` | Search-grid spacing |
 | `INTERCEPT_ARRIVAL_OFFSETS_HOURS` | `-12,-6,0,6,12` | Arrival offsets around closest approach |
 | `LEO_ALTITUDE_KM` | `500` | Parking orbit for approximate injection Δv |
+| `FINAL_ORBIT_COUNT` | `10` | Number of post-capture asteroid orbits to validate and animate |
 | `EPHEMERIS_MODE` | `analytic` | Deterministic Earth model or `skyfield` |
 | `JPL_EPHEMERIS_PATH` | empty | Optional local JPL DE kernel |
 | `FLASK_HOST` / `FLASK_PORT` | `127.0.0.1` / `5000` | Local dashboard address |
@@ -135,7 +137,7 @@ The generated viewer JSON and API caches are deliberately not committed.
 
 ## Mathematical model
 
-The planner uses osculating two-body elements in the ecliptic J2000 frame and a universal-variable Lambert solver. Every accepted Lambert solution is independently propagated to the requested arrival epoch and must satisfy an endpoint residual threshold.
+The planner uses osculating two-body elements in the ecliptic J2000 frame and a Julia universal-variable Lambert solver. Every accepted Lambert solution is independently propagated to the requested arrival epoch and must satisfy an endpoint residual threshold. The Julia backend then estimates asteroid-local capture and a final circular orbit from a documented density-sphere model; the viewer animates the spacecraft through the configured post-capture orbit count after intercept.
 
 See [docs/math.md](docs/math.md) for the derivation, frames, assumptions, validation strategy, and interpretation of Δv/C3 values.
 
@@ -144,13 +146,14 @@ See [docs/math.md](docs/math.md) for the derivation, frames, assumptions, valida
 ```bash
 python -m pip install -e ".[dev]"
 pytest
+JULIA_DEPOT_PATH=.local/julia_depot .local/julia/1.12.6/bin/julia --project=. -e 'using Pkg; Pkg.test()'
 ruff format --check app scripts/orbital.py scripts/ephem_earth.py \
   scripts/hud_metrics.py scripts/plan_intercepts.py scripts/sbdb_client.py tests run.py
 ruff check app scripts/orbital.py scripts/ephem_earth.py \
   scripts/hud_metrics.py scripts/plan_intercepts.py scripts/sbdb_client.py tests run.py
 ```
 
-Tests cover database idempotency, read-only SQL enforcement, Flask routes, planetary propagation, 3D mission loading, Kepler propagation, and Lambert endpoint closure.
+Tests cover database idempotency, read-only SQL enforcement, Flask routes, planetary propagation, 3D mission loading, Kepler propagation, Lambert endpoint closure, density-sphere capture estimates, and final-orbit propagation.
 
 ## Scope and limitations
 
@@ -160,7 +163,8 @@ Tests cover database idempotency, read-only SQL enforcement, Flask routes, plane
 - `EPHEMERIS_MODE=skyfield` provides an optional JPL DE Earth state.
 - Asteroid elements are osculating and are not numerically integrated with perturbations.
 - C3 and LEO departure Δv are preliminary patched-conic estimates.
-- No launch vehicle, finite-burn, capture, navigation, or uncertainty design is performed.
+- Asteroid capture and final-orbit results use estimated spherical mass properties when direct physical data is missing.
+- No launch vehicle, finite-burn, stationkeeping, navigation, or uncertainty design is performed.
 
 ## License
 

--- a/app/config.py
+++ b/app/config.py
@@ -54,6 +54,7 @@ class Settings:
     tof_step_days: int
     arrival_offsets_hours: tuple[int, ...]
     leo_altitude_km: float
+    final_orbit_count: float
 
 
 def get_settings() -> Settings:
@@ -83,4 +84,5 @@ def get_settings() -> Settings:
         tof_step_days=_env_int("INTERCEPT_TOF_STEP_DAYS", 10),
         arrival_offsets_hours=offsets,
         leo_altitude_km=_env_float("LEO_ALTITUDE_KM", 500.0),
+        final_orbit_count=_env_float("FINAL_ORBIT_COUNT", 10.0),
     )

--- a/app/database.py
+++ b/app/database.py
@@ -43,6 +43,19 @@ def initialize_database(path: Path | None = None) -> Path:
         if schema_version < 2:
             connection.executescript(schema)
             connection.commit()
+        elif schema_version < 3:
+            existing = {
+                row["name"]
+                for row in connection.execute("PRAGMA table_info(intercept_plans)").fetchall()
+            }
+            if "capture_dv_kms" not in existing:
+                connection.execute("ALTER TABLE intercept_plans ADD COLUMN capture_dv_kms REAL")
+            if "stable_final_orbit" not in existing:
+                connection.execute("ALTER TABLE intercept_plans ADD COLUMN stable_final_orbit INTEGER")
+            if "capture_json" not in existing:
+                connection.execute("ALTER TABLE intercept_plans ADD COLUMN capture_json TEXT")
+            connection.executescript(schema)
+            connection.commit()
     return database_path
 
 
@@ -215,13 +228,15 @@ def upsert_payload(payload: dict[str, Any], path: Path | None = None) -> dict[st
                 departure = plan.get("depart_jd_tdb", plan.get("departure_jd_tdb"))
                 arrival = plan.get("arrive_jd_tdb", plan.get("arrival_jd_tdb"))
                 total_dv = float(plan["dv_sum_mps"]) / 1000.0
+                capture = plan.get("capture") if isinstance(plan.get("capture"), dict) else None
                 connection.execute(
                     """
                     INSERT INTO intercept_plans(
                         approach_id, method, departure_jd_tdb, arrival_jd_tdb,
                         tof_days, departure_dv_kms, arrival_dv_kms, total_dv_kms,
-                        c3_km2_s2, leo_departure_dv_kms, polyline_json, computed_at
-                    ) VALUES (?, 'lambert-universal-v1', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        c3_km2_s2, leo_departure_dv_kms, capture_dv_kms,
+                        stable_final_orbit, capture_json, polyline_json, computed_at
+                    ) VALUES (?, 'lambert-universal-v1', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(approach_id, method) DO UPDATE SET
                         departure_jd_tdb=excluded.departure_jd_tdb,
                         arrival_jd_tdb=excluded.arrival_jd_tdb,
@@ -231,6 +246,9 @@ def upsert_payload(payload: dict[str, Any], path: Path | None = None) -> dict[st
                         total_dv_kms=excluded.total_dv_kms,
                         c3_km2_s2=excluded.c3_km2_s2,
                         leo_departure_dv_kms=excluded.leo_departure_dv_kms,
+                        capture_dv_kms=excluded.capture_dv_kms,
+                        stable_final_orbit=excluded.stable_final_orbit,
+                        capture_json=excluded.capture_json,
                         polyline_json=excluded.polyline_json,
                         computed_at=excluded.computed_at
                     """,
@@ -244,6 +262,9 @@ def upsert_payload(payload: dict[str, Any], path: Path | None = None) -> dict[st
                         total_dv,
                         plan.get("c3_km2_s2"),
                         plan.get("leo_dv_kms"),
+                        capture.get("capture_dv_kms") if capture else None,
+                        int(bool(capture.get("stable_final_orbit"))) if capture else None,
+                        json.dumps(capture) if capture else None,
                         json.dumps(
                             plan.get("lambert_polyline_xyz_au")
                             or plan.get("lambert_polyline_xy_au")

--- a/app/export.py
+++ b/app/export.py
@@ -22,7 +22,7 @@ def build_viewer_payload(path: Path | None = None) -> dict[str, Any]:
             oe.mean_anomaly_deg, oe.perihelion_time_jd_tdb,
             ip.departure_jd_tdb, ip.arrival_jd_tdb, ip.tof_days,
             ip.departure_dv_kms, ip.arrival_dv_kms, ip.total_dv_kms,
-            ip.c3_km2_s2, ip.leo_departure_dv_kms, ip.polyline_json
+            ip.c3_km2_s2, ip.leo_departure_dv_kms, ip.capture_json, ip.polyline_json
         FROM asteroids a
         JOIN close_approaches ca ON ca.designation = a.designation
         JOIN orbital_elements oe ON oe.designation = a.designation
@@ -61,6 +61,7 @@ def build_viewer_payload(path: Path | None = None) -> dict[str, Any]:
                     "dv_total_kms": row["total_dv_kms"],
                     "c3_km2_s2": row["c3_km2_s2"],
                     "leo_dv_kms": row["leo_departure_dv_kms"],
+                    "capture": json.loads(row["capture_json"] or "null"),
                     "lambert_polyline_xyz_au": json.loads(row["polyline_json"] or "[]"),
                 },
             }

--- a/app/ingest.py
+++ b/app/ingest.py
@@ -57,6 +57,7 @@ def collect_payload(settings: Settings) -> dict[str, Any]:
         tof_days_grid=tof_grid,
         arrive_offset_hours=list(settings.arrival_offsets_hours),
         leo_alt_m=settings.leo_altitude_km * 1000.0,
+        final_orbits=settings.final_orbit_count,
     )
 
 

--- a/app/neo_viewer_qt.py
+++ b/app/neo_viewer_qt.py
@@ -168,9 +168,17 @@ class SolarSystemView(gl.GLViewWidget):
             size=7,
             pxMode=True,
         )
+        self.final_orbit_path = gl.GLLinePlotItem(
+            pos=np.empty((0, 3), dtype=np.float32),
+            color=(0.42, 1.0, 0.82, 0.78),
+            width=2.0,
+            antialias=True,
+            mode="line_strip",
+        )
         for item in (
             self.asteroid_orbit,
             self.transfer_path,
+            self.final_orbit_path,
             self.transfer_trail,
             self.departure_dot,
             self.arrival_dot,
@@ -196,12 +204,16 @@ class SolarSystemView(gl.GLViewWidget):
         self.transfer_trail.setData(pos=mission.polyline_au[:1])
         self.departure_dot.setData(pos=mission.polyline_au[:1])
         self.arrival_dot.setData(pos=mission.polyline_au[-1:])
+        if mission.final_orbit_polyline_au is not None:
+            self.final_orbit_path.setData(pos=mission.final_orbit_polyline_au)
+        else:
+            self.final_orbit_path.setData(pos=np.empty((0, 3), dtype=np.float32))
         for planet in PLANETS:
             elements = planet_elements(planet, mission.departure_jd)
             self.planet_orbits[planet.name].setData(pos=orbit_curve_au(elements))
         self.update_time(mission.departure_jd, 0.0)
 
-    def update_time(self, jd_tdb: float, progress: float) -> np.ndarray:
+    def update_time(self, jd_tdb: float, elapsed_days: float) -> np.ndarray:
         if self.mission is None:
             return np.zeros(3)
         self.current_jd = jd_tdb
@@ -218,12 +230,28 @@ class SolarSystemView(gl.GLViewWidget):
         self.object_positions["Target"] = asteroid_position
 
         path = self.mission.polyline_au
-        position = max(0.0, min(1.0, progress)) * (len(path) - 1)
-        low = int(position)
-        high = min(low + 1, len(path) - 1)
-        fraction = position - low
-        spacecraft = path[low] * (1.0 - fraction) + path[high] * fraction
-        trail = np.vstack([path[: low + 1], spacecraft]).astype(np.float32)
+        transfer_progress = max(0.0, min(1.0, elapsed_days / max(self.mission.tof_days, 1e-9)))
+        if elapsed_days <= self.mission.tof_days or self.mission.final_orbit_polyline_au is None:
+            position = transfer_progress * (len(path) - 1)
+            low = int(position)
+            high = min(low + 1, len(path) - 1)
+            fraction = position - low
+            spacecraft = path[low] * (1.0 - fraction) + path[high] * fraction
+            trail = np.vstack([path[: low + 1], spacecraft]).astype(np.float32)
+        else:
+            orbit = self.mission.final_orbit_polyline_au
+            capture_elapsed = elapsed_days - self.mission.tof_days
+            capture_progress = max(
+                0.0,
+                min(1.0, capture_elapsed / max(self.mission.capture_duration_days, 1e-9)),
+            )
+            position = capture_progress * (len(orbit) - 1)
+            low = int(position)
+            high = min(low + 1, len(orbit) - 1)
+            fraction = position - low
+            spacecraft = orbit[low] * (1.0 - fraction) + orbit[high] * fraction
+            orbit_trail = np.vstack([orbit[: low + 1], spacecraft]).astype(np.float32)
+            trail = np.vstack([path, orbit_trail]).astype(np.float32)
         self.transfer_trail.setData(pos=trail)
         self.spacecraft_dot.setData(pos=spacecraft.reshape(1, 3))
         self.spacecraft_halo.setData(pos=spacecraft.reshape(1, 3))
@@ -626,7 +654,7 @@ class MissionViewerWidget(QtWidgets.QWidget):
         playback_row.addWidget(self.speed_combo, 1)
         panel_layout.addLayout(playback_row)
 
-        self.repeat_checkbox = QtWidgets.QCheckBox("Repeat mission on arrival")
+        self.repeat_checkbox = QtWidgets.QCheckBox("Repeat full sequence")
         self.repeat_checkbox.setChecked(True)
         panel_layout.addWidget(self.repeat_checkbox)
 
@@ -641,7 +669,10 @@ class MissionViewerWidget(QtWidgets.QWidget):
                 ("approach", "Close approach"),
                 ("distance", "Miss distance"),
                 ("tof", "Time of flight"),
+                ("duration", "Playback duration"),
                 ("dv", "Total Δv"),
+                ("capture", "Capture Δv"),
+                ("stability", "Final orbit"),
                 ("c3", "C3 estimate"),
                 ("position", "Spacecraft position"),
             )
@@ -774,19 +805,37 @@ class MissionViewerWidget(QtWidgets.QWidget):
         self.telemetry["approach"].setText(mission.approach_text)
         self.telemetry["distance"].setText(f"{mission.distance_au:.6f} AU")
         self.telemetry["tof"].setText(f"{mission.tof_days:.1f} days")
+        self.telemetry["duration"].setText(f"{mission.total_duration_days:.1f} days")
         self.telemetry["dv"].setText(f"{mission.total_dv_kms:.3f} km/s")
+        capture = mission.capture or {}
+        capture_dv = capture.get("capture_dv_kms")
+        self.telemetry["capture"].setText(
+            f"{float(capture_dv):.6f} km/s" if capture_dv is not None else "—"
+        )
+        if capture:
+            self.telemetry["stability"].setText(
+                "stable" if capture.get("stable_final_orbit") else "flagged"
+            )
+        else:
+            self.telemetry["stability"].setText("—")
         self.telemetry["c3"].setText(
             f"{mission.c3_km2_s2:.3f} km²/s²" if mission.c3_km2_s2 is not None else "—"
         )
 
     def _render_time(self) -> None:
         mission = self.mission
-        progress = self.elapsed_days / max(mission.tof_days, 1e-9)
+        total_duration = max(mission.total_duration_days, 1e-9)
+        progress = self.elapsed_days / total_duration
         jd = mission.departure_jd + self.elapsed_days
-        spacecraft = self.view.update_time(jd, progress)
+        spacecraft = self.view.update_time(jd, self.elapsed_days)
         self.date_label.setText(format_jd(jd))
-        self.elapsed_label.setText(f"T+ {self.elapsed_days:06.2f} / {mission.tof_days:.1f} d")
-        self.phase_label.setText("ARRIVAL" if progress >= 0.9999 else "COASTING")
+        self.elapsed_label.setText(f"T+ {self.elapsed_days:06.2f} / {total_duration:.1f} d")
+        if self.elapsed_days < mission.tof_days:
+            self.phase_label.setText("COASTING")
+        elif mission.capture_duration_days > 0.0 and self.elapsed_days < total_duration:
+            self.phase_label.setText("CAPTURE ORBIT")
+        else:
+            self.phase_label.setText("COMPLETE")
         self.telemetry["position"].setText(
             f"{spacecraft[0]:+.3f}, {spacecraft[1]:+.3f}, {spacecraft[2]:+.3f} AU"
         )
@@ -801,11 +850,12 @@ class MissionViewerWidget(QtWidgets.QWidget):
             return
         seconds = self.TIMER_INTERVAL_MS / 1000.0
         self.elapsed_days += float(self.speed_combo.currentData()) * seconds
-        if self.elapsed_days >= self.mission.tof_days:
+        total_duration = max(self.mission.total_duration_days, 1e-9)
+        if self.elapsed_days >= total_duration:
             if self.repeat_checkbox.isChecked():
-                self.elapsed_days %= self.mission.tof_days
+                self.elapsed_days %= total_duration
             else:
-                self.elapsed_days = self.mission.tof_days
+                self.elapsed_days = total_duration
                 self.playing = False
                 self.play_button.setText("Play")
         self._render_time()
@@ -839,7 +889,7 @@ class MissionViewerWidget(QtWidgets.QWidget):
     def _scrub_to(self, value: int) -> None:
         if not self._scrubbing:
             return
-        self.elapsed_days = self.mission.tof_days * value / 1000.0
+        self.elapsed_days = self.mission.total_duration_days * value / 1000.0
         self._render_time()
 
     def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:

--- a/app/schema.sql
+++ b/app/schema.sql
@@ -1,5 +1,5 @@
 PRAGMA foreign_keys = ON;
-PRAGMA user_version = 2;
+PRAGMA user_version = 3;
 
 CREATE TABLE IF NOT EXISTS ingestion_runs (
     run_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -69,6 +69,9 @@ CREATE TABLE IF NOT EXISTS intercept_plans (
     total_dv_kms REAL NOT NULL,
     c3_km2_s2 REAL,
     leo_departure_dv_kms REAL,
+    capture_dv_kms REAL,
+    stable_final_orbit INTEGER,
+    capture_json TEXT,
     polyline_json TEXT,
     computed_at TEXT NOT NULL,
     UNIQUE (approach_id, method)
@@ -80,6 +83,8 @@ CREATE INDEX IF NOT EXISTS idx_approaches_designation
     ON close_approaches(designation);
 CREATE INDEX IF NOT EXISTS idx_plans_total_dv
     ON intercept_plans(total_dv_kms);
+CREATE INDEX IF NOT EXISTS idx_plans_capture_dv
+    ON intercept_plans(capture_dv_kms);
 
 DROP VIEW IF EXISTS latest_asteroid_summary;
 CREATE VIEW latest_asteroid_summary AS
@@ -103,7 +108,9 @@ SELECT
     ip.arrival_dv_kms,
     ip.total_dv_kms,
     ip.c3_km2_s2,
-    ip.leo_departure_dv_kms
+    ip.leo_departure_dv_kms,
+    ip.capture_dv_kms,
+    ip.stable_final_orbit
 FROM asteroids a
 JOIN close_approaches ca ON ca.approach_id = (
     SELECT ca2.approach_id

--- a/app/solar_system.py
+++ b/app/solar_system.py
@@ -106,10 +106,25 @@ class Mission:
     c3_km2_s2: float | None
     leo_dv_kms: float | None
     polyline_au: np.ndarray
+    capture: dict[str, Any]
+    final_orbit_polyline_au: np.ndarray | None
 
     @property
     def label(self) -> str:
         return f"{self.designation}  ·  {self.approach_text}  ·  Δv {self.total_dv_kms:.2f} km/s"
+
+    @property
+    def capture_duration_days(self) -> float:
+        if self.final_orbit_polyline_au is None:
+            return 0.0
+        try:
+            return max(0.0, float(self.capture.get("propagation_days") or 0.0))
+        except (TypeError, ValueError):
+            return 0.0
+
+    @property
+    def total_duration_days(self) -> float:
+        return self.tof_days + self.capture_duration_days
 
 
 def julian_centuries(jd_tdb: float) -> float:
@@ -218,6 +233,8 @@ def load_missions(path: Path) -> list[Mission]:
         polyline = intercept.get("lambert_polyline_xyz_au")
         if not polyline:
             polyline = intercept.get("lambert_polyline_xy_au")
+        capture = intercept.get("capture") if isinstance(intercept.get("capture"), dict) else {}
+        final_orbit_polyline = capture.get("orbit_polyline_heliocentric_au") if capture else None
         try:
             departure = float(departure_value)
             arrival = float(arrival_value)
@@ -246,6 +263,10 @@ def load_missions(path: Path) -> list[Mission]:
                     else None
                 ),
                 polyline_au=_polyline_xyz(polyline),
+                capture=capture,
+                final_orbit_polyline_au=(
+                    _polyline_xyz(final_orbit_polyline) if final_orbit_polyline else None
+                ),
             )
         except (KeyError, TypeError, ValueError):
             continue

--- a/app/templates/detail.html
+++ b/app/templates/detail.html
@@ -26,7 +26,7 @@
     <p class="eyebrow">MODEL SCOPE</p>
     <h2>What this estimate means</h2>
     <p>The planner searches a configurable time-of-flight and arrival-offset grid, solves the heliocentric two-body Lambert problem, and ranks solutions by departure plus arrival velocity mismatch.</p>
-    <p>Planetary perturbations, finite burns, launch windows, navigation uncertainty, and asteroid capture dynamics are outside this model.</p>
+    <p>Asteroid capture uses an estimated density-sphere final-orbit model; planetary perturbations, finite burns, launch windows, navigation uncertainty, and stationkeeping remain outside this model.</p>
   </article>
 </section>
 
@@ -46,4 +46,3 @@
   </table></div>
 </section>
 {% endblock %}
-

--- a/bin/plan_intercepts.jl
+++ b/bin/plan_intercepts.jl
@@ -1,0 +1,5 @@
+#!/usr/bin/env julia
+
+using AsteroidPlannerBackend
+
+exit(AsteroidPlannerBackend.run_cli())

--- a/docs/math.md
+++ b/docs/math.md
@@ -106,13 +106,38 @@ $$\Delta v_{\text{LEO}} = \sqrt{v_\infty^2 + v_{\text{escape}}^2} - v_{\text{cir
 
 This patched-conic mapping is useful for first-order comparison only. A rigorous Earth-departure design must transform the heliocentric asymptote into the correct geocentric frame and include launch-site and finite-burn constraints.
 
-## 8. Automated checks
+## 8. Asteroid capture and final orbit
+
+The Julia backend adds an asteroid-local capture estimate after the heliocentric rendezvous calculation. Because JPL close-approach records often do not provide mass or shape, this model is explicitly approximate:
+
+- use the reported diameter when available;
+- otherwise estimate diameter from absolute magnitude with albedo 0.14;
+- assume a spherical body with bulk density 2000 kg/m^3;
+- compute asteroid mass, gravitational parameter, Hill radius, surface gravity, circular speed, and escape speed from those assumptions.
+
+The target final orbit starts as a circular orbit at three asteroid radii from the center. The orbit is flagged as implausible when it lies outside one third of the estimated Hill radius or when propagation intersects the surface or exceeds the same Hill-fraction bound. The arrival velocity mismatch is treated as asteroid-relative hyperbolic excess speed:
+
+$$v_\infty \approx \Delta v_{\text{arrive}}.$$
+
+At target orbit radius $r$,
+
+$$v_{\text{escape,ast}} = \sqrt{\frac{2\mu_{\text{ast}}}{r}}, \qquad
+v_{\text{circular,ast}} = \sqrt{\frac{\mu_{\text{ast}}}{r}},$$
+
+$$v_{\text{periapsis}} = \sqrt{v_\infty^2 + v_{\text{escape,ast}}^2}, \qquad
+\Delta v_{\text{capture}} = |v_{\text{periapsis}} - v_{\text{circular,ast}}|.$$
+
+The final circular orbit is propagated for the configured post-capture orbit count, ten orbits by default, capped at 30 days. It is exported both in asteroid-relative metres and heliocentric AU so the viewer can animate the spacecraft after intercept for the same duration the backend validated. This does not model irregular gravity fields, asteroid rotation, stationkeeping, navigation errors, or solar-radiation pressure.
+
+## 9. Automated checks
 
 The test suite verifies:
 
 - Kepler-equation residuals;
 - one-period closure of a circular Earth orbit;
 - Lambert propagation to a known Earth-to-Mars-like endpoint;
+- density-sphere asteroid mass and capture-burn calculations;
+- bounded final-orbit propagation and stability flags;
 - finite, physically plausible states and 3D orbit curves for all eight planets;
 - mission selection data and legacy-path compatibility;
 - rejection of nonpositive transfer time;
@@ -121,7 +146,7 @@ The test suite verifies:
 - read-only SQL enforcement; and
 - dashboard, detail, API, and health routes.
 
-## 9. Limitations
+## 10. Limitations
 
 The current model omits:
 
@@ -129,9 +154,9 @@ The current model omits:
 - covariance propagation and encounter uncertainty;
 - multi-revolution Lambert branches;
 - continuous launch-window optimization;
-- planetary sphere-of-influence transitions;
+- high-fidelity planetary sphere-of-influence transitions;
 - launch vehicle performance and finite burns;
-- terminal guidance, capture, and proximity operations.
+- terminal guidance, stationkeeping, surface operations, and proximity navigation.
 
 The results are appropriate for preliminary comparison, visualization, and software demonstration—not flight decisions.
 

--- a/scripts/plan_intercepts.py
+++ b/scripts/plan_intercepts.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +25,86 @@ from scripts.orbital import (
 )
 
 DAY_S = 86400.0
+ROOT_DIR = Path(__file__).resolve().parents[1]
+LOCAL_JULIA = ROOT_DIR / ".local" / "julia" / "1.12.6" / "bin" / "julia"
+JULIA_PROJECT = ROOT_DIR
+JULIA_CLI = ROOT_DIR / "bin" / "plan_intercepts.jl"
+JULIA_DEPOT = ROOT_DIR / ".local" / "julia_depot"
+
+
+def _julia_executable() -> str:
+    configured = os.getenv("JULIA", "").strip()
+    if configured:
+        return configured
+    if LOCAL_JULIA.exists():
+        return str(LOCAL_JULIA)
+    found = shutil.which("julia")
+    if found:
+        return found
+    raise RuntimeError(
+        "Julia calculation backend is required. Install Julia or set JULIA to the binary path."
+    )
+
+
+def _uses_local_julia(executable: str) -> bool:
+    try:
+        return Path(executable).resolve() == LOCAL_JULIA.resolve()
+    except OSError:
+        return False
+
+
+def _run_julia_backend(
+    payload: dict[str, Any],
+    tof_days_grid: list[int],
+    arrive_offset_hours: list[int],
+    leo_alt_m: float,
+    final_orbits: float,
+) -> dict[str, Any]:
+    if not tof_days_grid:
+        raise ValueError("tof_days_grid must not be empty")
+    step = tof_days_grid[1] - tof_days_grid[0] if len(tof_days_grid) > 1 else 1
+    arrive_hours = ",".join(str(value) for value in arrive_offset_hours)
+    executable = _julia_executable()
+    env = os.environ.copy()
+    if _uses_local_julia(executable):
+        env.setdefault("JULIA_DEPOT_PATH", str(JULIA_DEPOT))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_path = Path(tmpdir) / "payload.json"
+        output_path = Path(tmpdir) / "intercepts.json"
+        input_path.write_text(json.dumps(payload), encoding="utf-8")
+        command = [
+            executable,
+            f"--project={JULIA_PROJECT}",
+            str(JULIA_CLI),
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--tof-min",
+            str(min(tof_days_grid)),
+            "--tof-max",
+            str(max(tof_days_grid)),
+            "--tof-step",
+            str(step),
+            "--arrive-hours",
+            arrive_hours,
+            "--leo-alt-m",
+            str(leo_alt_m),
+            "--final-orbits",
+            str(final_orbits),
+        ]
+        completed = subprocess.run(
+            command,
+            check=False,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if completed.returncode != 0:
+            message = (completed.stderr or completed.stdout or "Julia backend failed").strip()
+            raise RuntimeError(f"Julia calculation backend failed: {message[-2000:]}")
+        return json.loads(output_path.read_text(encoding="utf-8"))
 
 
 def _asteroid_M_at_time(el: dict[str, Any], t_jd: float) -> float | None:
@@ -148,28 +232,13 @@ def attach_intercepts(
     tof_days_grid: list[int] | None = None,
     arrive_offset_hours: list[int] | None = None,
     leo_alt_m: float = 500e3,
+    final_orbits: float = 10.0,
 ) -> dict[str, Any]:
     if tof_days_grid is None:
         tof_days_grid = list(range(30, 181, 10))
     if arrive_offset_hours is None:
         arrive_offset_hours = [-12, -6, 0, 6, 12]
-
-    for o in payload.get("objects", []):
-        o["intercept"] = plan_intercept_for_object(
-            o,
-            tof_days_grid=tof_days_grid,
-            arrive_offset_hours=arrive_offset_hours,
-            leo_alt_m=leo_alt_m,
-        )
-
-    payload["intercept_note"] = {
-        "frame": "heliocentric ecliptic (Sun μ)",
-        "earth_model": "configured analytic or Skyfield ephemeris",
-        "cost": "minimize |v1−vE| + |vast−v2|",
-        "dv_units": "km/s",
-        "time_scale": "TDB JD",
-    }
-    return payload
+    return _run_julia_backend(payload, tof_days_grid, arrive_offset_hours, leo_alt_m, final_orbits)
 
 
 def main():
@@ -181,13 +250,18 @@ def main():
     ap.add_argument("--tof-max", type=int, default=180)
     ap.add_argument("--tof-step", type=int, default=10)
     ap.add_argument("--arrive-hours", default="-12,-6,0,6,12")
+    ap.add_argument("--final-orbits", type=float, default=10.0)
     args = ap.parse_args()
 
     src = json.loads(Path(args.inp).read_text())
     tof = list(range(args.tof_min, args.tof_max + 1, args.tof_step))
     offs = [int(s) for s in args.arrive_hours.split(",") if s]
     out = attach_intercepts(
-        src, tof_days_grid=tof, arrive_offset_hours=offs, leo_alt_m=args.leo_alt_m
+        src,
+        tof_days_grid=tof,
+        arrive_offset_hours=offs,
+        leo_alt_m=args.leo_alt_m,
+        final_orbits=args.final_orbits,
     )
     Path(args.out).write_text(json.dumps(out, indent=2))
     print(f"Wrote {args.out}")

--- a/src/AsteroidPlannerBackend.jl
+++ b/src/AsteroidPlannerBackend.jl
@@ -1,0 +1,640 @@
+module AsteroidPlannerBackend
+
+using JSON
+using LinearAlgebra
+
+const AU_M = 149_597_870_700.0
+const DAY_S = 86_400.0
+const MU_SUN = 1.32712440018e20
+const MU_EARTH = 3.986004418e14
+const R_EARTH_M = 6_378_137.0
+const G_M3_KG_S2 = 6.67430e-11
+const JD_J2000 = 2_451_545.0
+const DEFAULT_DENSITY_KG_M3 = 2_000.0
+const DEFAULT_ALBEDO = 0.14
+
+deg2rad(x) = Float64(x) * pi / 180.0
+wrap_2pi(x) = mod(Float64(x), 2.0 * pi)
+
+function finite_positive(x)
+    return x !== nothing && isfinite(Float64(x)) && Float64(x) > 0.0
+end
+
+function maybe_float(value)
+    value === nothing && return nothing
+    try
+        return Float64(value)
+    catch
+        return nothing
+    end
+end
+
+function get_float(dict::AbstractDict, key::AbstractString)
+    return haskey(dict, key) ? maybe_float(dict[key]) : nothing
+end
+
+function kepler_E_from_M(M, e; tol=1e-12, itmax=60)
+    M = wrap_2pi(M)
+    e = Float64(e)
+    e < 1e-12 && return M
+    E = e < 0.8 ? M : pi
+    for _ in 1:itmax
+        f = E - e * sin(E) - M
+        fp = 1.0 - e * cos(E)
+        dE = -f / fp
+        E += dE
+        abs(dE) < tol && break
+    end
+    return E
+end
+
+function oe_to_rv(a_m, e, i, raan, argp, nu; mu=MU_SUN)
+    a_m = Float64(a_m)
+    e = Float64(e)
+    p = a_m * (1.0 - e * e)
+    p > 0.0 || throw(ArgumentError("orbital elements require positive semilatus rectum"))
+    cnu, snu = cos(nu), sin(nu)
+    r_pf = [p * cnu / (1.0 + e * cnu), p * snu / (1.0 + e * cnu), 0.0]
+    v_pf = [-sqrt(mu / p) * snu, sqrt(mu / p) * (e + cnu), 0.0]
+
+    ci, si = cos(i), sin(i)
+    cO, sO = cos(raan), sin(raan)
+    co, so = cos(argp), sin(argp)
+    R = [
+        cO * co - sO * so * ci  -cO * so - sO * co * ci   sO * si
+        sO * co + cO * so * ci  -sO * so + cO * co * ci  -cO * si
+        so * si                  co * si                   ci
+    ]
+    return R * r_pf, R * v_pf
+end
+
+function stumpff_C(z)
+    z = Float64(z)
+    abs(z) < 1e-8 && return 0.5 - z / 24.0 + z * z / 720.0
+    if z > 0.0
+        s = sqrt(z)
+        return (1.0 - cos(s)) / z
+    end
+    s = sqrt(-z)
+    s <= 700.0 || throw(OverflowError("Stumpff C overflow"))
+    return (cosh(s) - 1.0) / (-z)
+end
+
+function stumpff_S(z)
+    z = Float64(z)
+    abs(z) < 1e-8 && return (1.0 / 6.0) - z / 120.0 + z * z / 5040.0
+    if z > 0.0
+        s = sqrt(z)
+        return (s - sin(s)) / s^3
+    end
+    s = sqrt(-z)
+    s <= 700.0 || throw(OverflowError("Stumpff S overflow"))
+    return (sinh(s) - s) / s^3
+end
+
+function kepler_universal_propagate(r0, v0, dt; mu=MU_SUN, itmax=80, tol=1e-6)
+    r0 = Float64.(collect(r0))
+    v0 = Float64.(collect(v0))
+    dt = Float64(dt)
+    r0n = norm(r0)
+    r0n > 0.0 || throw(ArgumentError("kepler_universal_propagate: |r0| is zero"))
+    r0_dot_v0 = dot(r0, v0)
+    alpha = 2.0 / r0n - dot(v0, v0) / mu
+    sqrt_mu = sqrt(mu)
+
+    if abs(alpha) > 1e-12
+        chi = sqrt_mu * abs(alpha) * dt
+    else
+        h = norm(cross(r0, v0))
+        p = h * h / mu
+        p > 0.0 || throw(ArgumentError("kepler_universal_propagate: degenerate angular momentum"))
+        s = 0.5 * (pi / 2.0 - atan(3.0 * sqrt(mu / p^3) * dt))
+        w = atan(tan(s)^(1.0 / 3.0))
+        chi = sqrt(p) * 2.0 / tan(2.0 * w)
+    end
+
+    converged = false
+    for _ in 1:itmax
+        z = alpha * chi * chi
+        C = stumpff_C(z)
+        S = stumpff_S(z)
+        F = (r0_dot_v0 / sqrt_mu) * chi^2 * C +
+            (1.0 - alpha * r0n) * chi^3 * S +
+            r0n * chi - sqrt_mu * dt
+        dF = (r0_dot_v0 / sqrt_mu) * chi * (1.0 - z * S) +
+            (1.0 - alpha * r0n) * chi^2 * C + r0n
+        if abs(F) < tol * sqrt_mu
+            converged = true
+            break
+        end
+        abs(dF) > 1e-16 || throw(ErrorException("Kepler propagation derivative vanished"))
+        chi -= F / dF
+    end
+    converged || throw(ErrorException("Kepler universal-variable solver did not converge"))
+
+    z = alpha * chi * chi
+    C = stumpff_C(z)
+    S = stumpff_S(z)
+    f = 1.0 - chi^2 * C / r0n
+    g = dt - chi^3 * S / sqrt_mu
+    r = f .* r0 .+ g .* v0
+    rn = norm(r)
+    fdot = (sqrt_mu / (rn * r0n)) * (z * S - 1.0) * chi
+    gdot = 1.0 - chi^2 * C / rn
+    v = fdot .* r0 .+ gdot .* v0
+    return r, v
+end
+
+function lambert_universal(r1, r2, tof_s; mu=MU_SUN, prograde=true, max_iter=80, tol=1e-8)
+    r1 = Float64.(collect(r1))
+    r2 = Float64.(collect(r2))
+    tof_s = Float64(tof_s)
+    r1n = norm(r1)
+    r2n = norm(r2)
+    r1n > 0.0 && r2n > 0.0 || throw(ArgumentError("Lambert: |r1| or |r2| is zero"))
+    tof_s > 0.0 || throw(ArgumentError("Lambert: time of flight must be positive"))
+    cosd = clamp(dot(r1, r2) / (r1n * r2n + 1e-16), -1.0, 1.0)
+    dtheta = acos(cosd)
+    cz = cross(r1, r2)[3]
+    if prograde && cz < 0.0
+        dtheta = 2.0 * pi - dtheta
+    elseif !prograde && cz > 0.0
+        dtheta = 2.0 * pi - dtheta
+    end
+
+    denom = 1.0 - cosd
+    abs(denom) >= 1e-16 || throw(ArgumentError("Lambert geometry singular"))
+    A = sin(dtheta) * sqrt(max(0.0, r1n * r2n / denom))
+    abs(A) >= 1e-14 || throw(ArgumentError("Lambert geometry singular: A≈0"))
+    sqrt_mu = sqrt(mu)
+
+    function y_of_z(z)
+        C = stumpff_C(z)
+        S = stumpff_S(z)
+        Ceff = abs(C) > 1e-16 ? C : 1e-16
+        return r1n + r2n + A * ((z * S - 1.0) / sqrt(Ceff))
+    end
+
+    function tof_of_z(z)
+        C = stumpff_C(z)
+        S = stumpff_S(z)
+        y = y_of_z(z)
+        y > 0.0 || return Inf
+        Ceff = abs(C) > 1e-16 ? C : 1e-16
+        x = sqrt(max(0.0, y / Ceff))
+        return (x^3 * S + A * sqrt(y)) / sqrt_mu
+    end
+
+    z_limit = 4.0 * pi^2 - 1e-6
+    previous = nothing
+    bracket = nothing
+    for candidate in range(-z_limit, z_limit; length=1200)
+        local value
+        try
+            value = tof_of_z(candidate) - tof_s
+        catch
+            continue
+        end
+        isfinite(value) || continue
+        if abs(value) <= tol
+            bracket = (Float64(candidate), Float64(candidate))
+            break
+        end
+        if previous !== nothing && previous[2] * value < 0.0
+            bracket = (previous[1], Float64(candidate))
+            break
+        end
+        previous = (Float64(candidate), value)
+    end
+    bracket !== nothing || throw(ErrorException("Lambert: no single-revolution time-of-flight root"))
+
+    z_lo, z_hi = bracket
+    z = z_lo
+    converged = z_lo == z_hi
+    for _ in 1:max_iter
+        converged && break
+        z = 0.5 * (z_lo + z_hi)
+        f_mid = tof_of_z(z) - tof_s
+        if abs(f_mid) <= tol
+            converged = true
+            break
+        end
+        f_lo = tof_of_z(z_lo) - tof_s
+        if f_lo * f_mid <= 0.0
+            z_hi = z
+        else
+            z_lo = z
+        end
+    end
+    if !converged
+        converged = abs(z_hi - z_lo) < 1e-12
+        z = 0.5 * (z_lo + z_hi)
+    end
+    converged || throw(ErrorException("Lambert: time-of-flight root did not converge"))
+
+    y = y_of_z(z)
+    y > 0.0 || throw(ErrorException("Lambert: y(z*) <= 0 at solution"))
+    f = 1.0 - y / r1n
+    g = A * sqrt(y / mu)
+    gdot = 1.0 - y / r2n
+    if abs(g) < 1e-14
+        g = copysign(1e-14, g)
+    end
+    v1 = (r2 .- f .* r1) ./ g
+    v2 = (gdot .* r2 .- r1) ./ g
+    propagated, _ = kepler_universal_propagate(r1, v1, tof_s; mu=mu)
+    residual_m = norm(propagated .- r2)
+    tolerance_m = max(10_000.0, 1e-7 * r2n)
+    if !isfinite(residual_m) || residual_m > tolerance_m
+        throw(ErrorException("Lambert endpoint residual $(residual_m) m exceeds $(tolerance_m) m"))
+    end
+    return v1, v2
+end
+
+function sample_transfer_polyline(r1, v1, tof_s, n=180; mu=MU_SUN)
+    points = Vector{Vector{Float64}}()
+    for k in 0:n
+        t = (k / n) * Float64(tof_s)
+        r, _ = kepler_universal_propagate(r1, v1, t; mu=mu)
+        push!(points, [r[1] / AU_M, r[2] / AU_M, r[3] / AU_M])
+    end
+    return points
+end
+
+function earth_rv_analytic(jd_tdb)
+    semi_major_axis = 1.00000011 * AU_M
+    eccentricity = 0.01671022
+    inclination = deg2rad(0.00005)
+    longitude_ascending_node = deg2rad(-11.26064)
+    longitude_perihelion = deg2rad(102.94719)
+    argument_perihelion = longitude_perihelion - longitude_ascending_node
+    mean_longitude_j2000 = deg2rad(100.46435)
+    mean_anomaly_j2000 = mean_longitude_j2000 - longitude_perihelion
+    mean_motion = sqrt(MU_SUN / semi_major_axis^3)
+    mean_anomaly = wrap_2pi(mean_anomaly_j2000 + mean_motion * (Float64(jd_tdb) - JD_J2000) * DAY_S)
+    eccentric_anomaly = kepler_E_from_M(mean_anomaly, eccentricity)
+    true_anomaly = 2.0 * atan(
+        sqrt(1.0 + eccentricity) * sin(eccentric_anomaly / 2.0),
+        sqrt(1.0 - eccentricity) * cos(eccentric_anomaly / 2.0),
+    )
+    return oe_to_rv(
+        semi_major_axis,
+        eccentricity,
+        inclination,
+        longitude_ascending_node,
+        argument_perihelion,
+        true_anomaly,
+    )
+end
+
+function asteroid_M_at_time(elements::AbstractDict, jd_tdb)
+    a = Float64(elements["a_AU"]) * AU_M
+    n = sqrt(MU_SUN / a^3)
+    tp = get_float(elements, "tp_jd_tdb")
+    if tp !== nothing
+        return wrap_2pi(n * ((Float64(jd_tdb) - tp) * DAY_S))
+    end
+    ma_deg = get_float(elements, "ma_deg")
+    epoch = get_float(elements, "epoch_jd_tdb")
+    if ma_deg === nothing || epoch === nothing
+        return nothing
+    end
+    return wrap_2pi(deg2rad(ma_deg) + n * (Float64(jd_tdb) - epoch) * DAY_S)
+end
+
+function asteroid_rv_from_elements(elements::AbstractDict, jd_tdb)
+    a = Float64(elements["a_AU"]) * AU_M
+    e = Float64(elements["e"])
+    inc = deg2rad(elements["i_deg"])
+    raan = deg2rad(elements["raan_deg"])
+    argp = deg2rad(elements["argp_deg"])
+    M = asteroid_M_at_time(elements, jd_tdb)
+    M !== nothing || throw(ArgumentError("insufficient elements to compute mean anomaly"))
+    E = kepler_E_from_M(M, e)
+    cE, sE = cos(E), sin(E)
+    r_peri = [a * (cE - e), a * (sqrt(1.0 - e * e) * sE), 0.0]
+    r_mag = a * (1.0 - e * cE)
+    fac = sqrt(MU_SUN * a) / r_mag
+    v_peri = [-fac * sE, fac * sqrt(1.0 - e * e) * cE, 0.0]
+
+    cO, sO = cos(raan), sin(raan)
+    ci, si = cos(inc), sin(inc)
+    cw, sw = cos(argp), sin(argp)
+    R = [
+        cO * cw - sO * sw * ci  -cO * sw - sO * cw * ci   sO * si
+        sO * cw + cO * sw * ci  -sO * sw + cO * cw * ci  -cO * si
+        sw * si                  cw * si                   ci
+    ]
+    return R * r_peri, R * v_peri
+end
+
+function leo_departure_dv(vinf_kms, leo_alt_m=500e3)
+    r = R_EARTH_M + Float64(leo_alt_m)
+    v_circ = sqrt(MU_EARTH / r)
+    v_esc = sqrt(2.0 * MU_EARTH / r)
+    v_hyp = sqrt((Float64(vinf_kms) * 1000.0)^2 + v_esc^2)
+    return (v_hyp - v_circ) / 1000.0
+end
+
+function diameter_from_H_m(H, albedo=DEFAULT_ALBEDO)
+    H = Float64(H)
+    albedo = Float64(albedo)
+    albedo > 0.0 || throw(ArgumentError("albedo must be positive"))
+    return 1329.0 / sqrt(albedo) * 10.0^(-H / 5.0) * 1000.0
+end
+
+function physical_radius_m(obj::AbstractDict, elements::AbstractDict, albedo=DEFAULT_ALBEDO)
+    ca = get(obj, "next_ca", Dict{String,Any}())
+    diameter_km = get_float(ca, "diameter_km")
+    if finite_positive(diameter_km)
+        return 0.5 * diameter_km * 1000.0, "diameter_km"
+    end
+    H = get_float(ca, "h")
+    H === nothing && (H = get_float(elements, "H"))
+    if H !== nothing && isfinite(H)
+        return 0.5 * diameter_from_H_m(H, albedo), "H_albedo"
+    end
+    return nothing, "missing"
+end
+
+function circular_orbit_state(radius_m, mu_ast)
+    r = [Float64(radius_m), 0.0, 0.0]
+    v = [0.0, sqrt(Float64(mu_ast) / Float64(radius_m)), 0.0]
+    return r, v
+end
+
+function propagate_two_body_relative(r0, v0, duration_s, samples; mu_ast)
+    points = Vector{Vector{Float64}}()
+    min_radius = Inf
+    max_radius = 0.0
+    for k in 0:samples
+        t = (k / samples) * Float64(duration_s)
+        r, _ = kepler_universal_propagate(r0, v0, t; mu=mu_ast)
+        radius = norm(r)
+        min_radius = min(min_radius, radius)
+        max_radius = max(max_radius, radius)
+        push!(points, [r[1], r[2], r[3]])
+    end
+    return points, min_radius, max_radius
+end
+
+function heliocentric_orbit_polyline(relative_points, elements::AbstractDict, arrival_jd, duration_s)
+    output = Vector{Vector{Float64}}()
+    count = max(length(relative_points) - 1, 1)
+    for (idx, relative) in enumerate(relative_points)
+        # Sample the asteroid ephemeris during the local-orbit validation span.
+        # The local orbit itself is modeled in a simple asteroid-centered frame;
+        # this overlay is only for viewer context at solar-system scale.
+        jd = Float64(arrival_jd) + ((idx - 1) / count) * (Float64(duration_s) / DAY_S)
+        r_ast, _ = asteroid_rv_from_elements(elements, jd)
+        r = r_ast .+ relative
+        push!(output, [r[1] / AU_M, r[2] / AU_M, r[3] / AU_M])
+    end
+    return output
+end
+
+function capture_model(obj::AbstractDict, elements::AbstractDict, arrival_jd, arrival_vinf_kms, dv_sum_mps; density=DEFAULT_DENSITY_KG_M3, albedo=DEFAULT_ALBEDO, final_orbits=10.0)
+    flags = String[]
+    density = Float64(density)
+    albedo = Float64(albedo)
+    final_orbits = Float64(final_orbits)
+    density > 0.0 || throw(ArgumentError("density must be positive"))
+    final_orbits > 0.0 || throw(ArgumentError("final_orbits must be positive"))
+    radius_value, source = physical_radius_m(obj, elements, albedo)
+    if radius_value === nothing || !finite_positive(radius_value)
+        return Dict{String,Any}(
+            "model" => "density-sphere-v1",
+            "density_kg_m3" => density,
+            "albedo" => albedo,
+            "diameter_source" => source,
+            "stable_final_orbit" => false,
+            "stability_flags" => ["missing physical size"],
+            "requested_final_orbits" => final_orbits,
+            "propagated_final_orbits" => 0.0,
+            "orbit_polyline_relative_m" => Any[],
+            "orbit_polyline_heliocentric_au" => Any[],
+        )
+    end
+
+    radius_m = Float64(radius_value)
+    volume_m3 = 4.0 / 3.0 * pi * radius_m^3
+    mass_kg = density * volume_m3
+    mu_ast = G_M3_KG_S2 * mass_kg
+    a_ast_m = Float64(elements["a_AU"]) * AU_M
+    hill_radius_m = a_ast_m * cbrt(mass_kg / (3.0 * (MU_SUN / G_M3_KG_S2)))
+    target_radius_m = 3.0 * radius_m
+    target_altitude_m = target_radius_m - radius_m
+
+    if !isfinite(hill_radius_m) || hill_radius_m <= 0.0
+        push!(flags, "invalid Hill radius")
+    elseif target_radius_m > hill_radius_m / 3.0
+        push!(flags, "target orbit outside one-third Hill radius")
+    end
+
+    circular_speed_mps = sqrt(mu_ast / target_radius_m)
+    escape_speed_mps = sqrt(2.0 * mu_ast / target_radius_m)
+    surface_gravity_m_s2 = mu_ast / radius_m^2
+    orbit_period_s = 2.0 * pi * sqrt(target_radius_m^3 / mu_ast)
+    arrival_vinf_mps = Float64(arrival_vinf_kms) * 1000.0
+    periapsis_speed_mps = sqrt(arrival_vinf_mps^2 + escape_speed_mps^2)
+    capture_dv_mps = abs(periapsis_speed_mps - circular_speed_mps)
+    propagation_s = min(final_orbits * orbit_period_s, 30.0 * DAY_S)
+    propagated_final_orbits = propagation_s / orbit_period_s
+    samples = 240
+
+    r0, v0 = circular_orbit_state(target_radius_m, mu_ast)
+    relative_polyline, min_radius_m, max_radius_m = propagate_two_body_relative(
+        r0, v0, propagation_s, samples; mu_ast=mu_ast
+    )
+    if min_radius_m <= radius_m
+        push!(flags, "surface intersection")
+    end
+    if max_radius_m >= hill_radius_m / 3.0
+        push!(flags, "propagation exceeds one-third Hill radius")
+    end
+    drift_m = max(abs(min_radius_m - target_radius_m), abs(max_radius_m - target_radius_m))
+    if drift_m > max(1.0, 1e-6 * target_radius_m)
+        push!(flags, "two-body propagation drift")
+    end
+    stable = isempty(flags)
+
+    return Dict{String,Any}(
+        "model" => "density-sphere-v1",
+        "density_kg_m3" => density,
+        "albedo" => albedo,
+        "diameter_source" => source,
+        "radius_m" => radius_m,
+        "mass_kg" => mass_kg,
+        "mu_m3_s2" => mu_ast,
+        "hill_radius_m" => hill_radius_m,
+        "target_orbit_radius_m" => target_radius_m,
+        "target_orbit_altitude_m" => target_altitude_m,
+        "surface_gravity_m_s2" => surface_gravity_m_s2,
+        "orbit_period_s" => orbit_period_s,
+        "circular_speed_mps" => circular_speed_mps,
+        "escape_speed_mps" => escape_speed_mps,
+        "arrival_vinf_kms" => Float64(arrival_vinf_kms),
+        "capture_dv_kms" => capture_dv_mps / 1000.0,
+        "dv_total_with_capture_kms" => Float64(dv_sum_mps) / 1000.0 + capture_dv_mps / 1000.0,
+        "stable_final_orbit" => stable,
+        "stability_flags" => flags,
+        "requested_final_orbits" => final_orbits,
+        "propagated_final_orbits" => propagated_final_orbits,
+        "propagation_days" => propagation_s / DAY_S,
+        "propagation_min_radius_m" => min_radius_m,
+        "propagation_max_radius_m" => max_radius_m,
+        "propagation_radial_drift_m" => drift_m,
+        "orbit_polyline_relative_m" => relative_polyline,
+        "orbit_polyline_heliocentric_au" => heliocentric_orbit_polyline(relative_polyline, elements, arrival_jd, propagation_s),
+    )
+end
+
+function plan_intercept_for_object(obj::AbstractDict; tof_days_grid=collect(30:10:180), arrive_offset_hours=[-12, -6, 0, 6, 12], leo_alt_m=500e3, final_orbits=10.0)
+    elements = get(obj, "elements", nothing)
+    ca = get(obj, "next_ca", nothing)
+    (elements isa AbstractDict && ca isa AbstractDict) || return nothing
+    haskey(ca, "jd_tdb") && ca["jd_tdb"] !== nothing || return nothing
+    jd_ca = Float64(ca["jd_tdb"])
+    best = nothing
+
+    for d_off in arrive_offset_hours
+        jd_arr = jd_ca + Float64(d_off) / 24.0
+        local r_ast_arr, v_ast_arr
+        try
+            r_ast_arr, v_ast_arr = asteroid_rv_from_elements(elements, jd_arr)
+        catch
+            continue
+        end
+        for tof_d in tof_days_grid
+            jd_dep = jd_arr - Float64(tof_d)
+            r_e_dep, v_e_dep = earth_rv_analytic(jd_dep)
+            tof_s = Float64(tof_d) * DAY_S
+            solution = nothing
+            for prograde in (true, false)
+                try
+                    solution = lambert_universal(r_e_dep, r_ast_arr, tof_s; mu=MU_SUN, prograde=prograde)
+                    break
+                catch
+                    continue
+                end
+            end
+            solution === nothing && continue
+            v1, v2 = solution
+            dv_dep = norm(v1 .- v_e_dep)
+            dv_arr = norm(v_ast_arr .- v2)
+            dv_sum = dv_dep + dv_arr
+            if best === nothing || dv_sum < best["dv_sum_mps"]
+                polyline = Any[]
+                try
+                    polyline = sample_transfer_polyline(r_e_dep, v1, tof_s, 180)
+                catch
+                    polyline = Any[]
+                end
+                plan = Dict{String,Any}(
+                    "depart_jd_tdb" => jd_dep,
+                    "arrive_jd_tdb" => jd_arr,
+                    "tof_days" => Float64(tof_d),
+                    "dv_depart_kms" => dv_dep / 1000.0,
+                    "dv_arrive_kms" => dv_arr / 1000.0,
+                    "dv_sum_mps" => dv_sum,
+                    "c3_km2_s2" => (dv_dep / 1000.0)^2,
+                    "vinf_kms" => dv_dep / 1000.0,
+                    "leo_dv_kms" => leo_departure_dv(dv_dep / 1000.0, leo_alt_m),
+                    "lambert_polyline_xyz_au" => polyline,
+                )
+                plan["capture"] = capture_model(obj, elements, jd_arr, dv_arr / 1000.0, dv_sum; final_orbits=final_orbits)
+                best = plan
+            end
+        end
+    end
+    return best
+end
+
+function attach_intercepts!(payload::AbstractDict; tof_days_grid=collect(30:10:180), arrive_offset_hours=[-12, -6, 0, 6, 12], leo_alt_m=500e3, final_orbits=10.0)
+    objects = get(payload, "objects", Any[])
+    for obj in objects
+        obj["intercept"] = plan_intercept_for_object(
+            obj;
+            tof_days_grid=tof_days_grid,
+            arrive_offset_hours=arrive_offset_hours,
+            leo_alt_m=leo_alt_m,
+            final_orbits=final_orbits,
+        )
+    end
+    payload["intercept_note"] = Dict{String,Any}(
+        "frame" => "heliocentric ecliptic (Sun μ)",
+        "earth_model" => "Julia analytic J2000 Kepler model",
+        "cost" => "minimize |v1−vE| + |vast−v2|",
+        "dv_units" => "km/s",
+        "time_scale" => "TDB JD",
+        "capture_model" => "density-sphere-v1",
+    )
+    return payload
+end
+
+function parse_int_list(text)
+    isempty(strip(text)) && return Int[]
+    return [parse(Int, strip(part)) for part in split(text, ",") if !isempty(strip(part))]
+end
+
+function run_cli(args=ARGS)
+    input = nothing
+    output = nothing
+    tof_min = 30
+    tof_max = 180
+    tof_step = 10
+    arrive_hours = "-12,-6,0,6,12"
+    leo_alt_m = 500e3
+    final_orbits = 10.0
+    idx = 1
+    while idx <= length(args)
+        arg = args[idx]
+        if arg in ("--input", "--inp")
+            idx += 1
+            input = args[idx]
+        elseif arg in ("--output", "--out")
+            idx += 1
+            output = args[idx]
+        elseif arg == "--tof-min"
+            idx += 1
+            tof_min = parse(Int, args[idx])
+        elseif arg == "--tof-max"
+            idx += 1
+            tof_max = parse(Int, args[idx])
+        elseif arg == "--tof-step"
+            idx += 1
+            tof_step = parse(Int, args[idx])
+        elseif arg == "--arrive-hours"
+            idx += 1
+            arrive_hours = args[idx]
+        elseif arg == "--leo-alt-m"
+            idx += 1
+            leo_alt_m = parse(Float64, args[idx])
+        elseif arg == "--final-orbits"
+            idx += 1
+            final_orbits = parse(Float64, args[idx])
+        else
+            throw(ArgumentError("unknown argument: $arg"))
+        end
+        idx += 1
+    end
+
+    source = input === nothing ? read(stdin, String) : read(input, String)
+    payload = JSON.parse(source)
+    tof_grid = collect(tof_min:tof_step:tof_max)
+    offsets = parse_int_list(arrive_hours)
+    attach_intercepts!(payload; tof_days_grid=tof_grid, arrive_offset_hours=offsets, leo_alt_m=leo_alt_m, final_orbits=final_orbits)
+    encoded = JSON.json(payload, 2)
+    if output === nothing
+        print(encoded)
+    else
+        write(output, encoded)
+    end
+    return 0
+end
+
+export AU_M, DAY_S, MU_SUN, DEFAULT_ALBEDO, DEFAULT_DENSITY_KG_M3
+export kepler_E_from_M, kepler_universal_propagate, lambert_universal
+export diameter_from_H_m, capture_model, attach_intercepts!, run_cli
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,105 @@
+using AsteroidPlannerBackend
+using Test
+using LinearAlgebra
+
+@testset "orbital mechanics" begin
+    M = 2.1
+    e = 0.63
+    E = kepler_E_from_M(M, e)
+    @test E - e * sin(E) ≈ M atol = 1e-11
+
+    position = [AU_M, 0.0, 0.0]
+    velocity = [0.0, sqrt(MU_SUN / AU_M), 0.0]
+    period = 2.0 * pi * sqrt(AU_M^3 / MU_SUN)
+    propagated, _ = kepler_universal_propagate(position, velocity, period)
+    @test norm(propagated - position) < 1_000.0
+
+    departure = [AU_M, 0.0, 0.0]
+    arrival = [0.0, 1.524 * AU_M, 0.0]
+    tof = 200.0 * DAY_S
+    departure_velocity, _ = lambert_universal(departure, arrival, tof)
+    endpoint, _ = kepler_universal_propagate(departure, departure_velocity, tof)
+    @test norm(endpoint - arrival) < 25_000.0
+    @test_throws ArgumentError lambert_universal(ones(3), [1.0, 2.0, 3.0], 0.0)
+end
+
+@testset "capture model" begin
+    diameter_m = diameter_from_H_m(22.0, 0.14)
+    @test diameter_m > 0.0
+    @test diameter_m ≈ 1329.0 / sqrt(0.14) * 10.0^(-22.0 / 5.0) * 1000.0
+
+    elements = Dict(
+        "epoch_jd_tdb" => 2.461e6,
+        "a_AU" => 1.2,
+        "e" => 0.1,
+        "i_deg" => 5.0,
+        "raan_deg" => 50.0,
+        "argp_deg" => 10.0,
+        "ma_deg" => 20.0,
+    )
+    obj = Dict(
+        "next_ca" => Dict("jd_tdb" => 2.4612e6, "diameter_km" => 10.0),
+        "elements" => elements,
+    )
+    capture = capture_model(obj, elements, 2.4612e6, 0.0, 5_000.0; final_orbits=4.0)
+    @test capture["model"] == "density-sphere-v1"
+    @test capture["radius_m"] ≈ 5_000.0
+    @test capture["mass_kg"] ≈ 2_000.0 * (4.0 / 3.0) * pi * 5_000.0^3
+    @test capture["mu_m3_s2"] ≈ 6.67430e-11 * capture["mass_kg"]
+    @test capture["circular_speed_mps"] > 0.0
+    @test capture["escape_speed_mps"] > capture["circular_speed_mps"]
+    @test capture["capture_dv_kms"] > 0.0
+    @test capture["propagation_max_radius_m"] >= capture["target_orbit_radius_m"]
+    @test length(capture["orbit_polyline_relative_m"]) == 241
+    @test length(capture["orbit_polyline_heliocentric_au"]) == 241
+    @test capture["requested_final_orbits"] == 4.0
+    @test capture["propagated_final_orbits"] ≈ 4.0
+    @test capture["propagation_days"] ≈ 4.0 * capture["orbit_period_s"] / DAY_S
+
+    faster_capture = capture_model(obj, elements, 2.4612e6, 1.0, 5_000.0; final_orbits=4.0)
+    @test faster_capture["capture_dv_kms"] > capture["capture_dv_kms"]
+
+    missing = capture_model(Dict("next_ca" => Dict()), elements, 2.4612e6, 1.0, 5_000.0; final_orbits=4.0)
+    @test missing["stable_final_orbit"] == false
+    @test "missing physical size" in missing["stability_flags"]
+end
+
+@testset "payload integration" begin
+    payload = Dict(
+        "schema" => "asteroid_intercept_planner/2.0",
+        "objects" => Any[
+            Dict(
+                "des" => "TEST-1",
+                "next_ca" => Dict(
+                    "jd_tdb" => 2_461_200.5,
+                    "cd_tdb" => "2026-Jul-09 00:00",
+                    "dist_au" => 0.0123,
+                    "diameter_km" => 1.0,
+                ),
+                "elements" => Dict(
+                    "epoch_jd_tdb" => 2_461_000.5,
+                    "a_AU" => 1.2,
+                    "e" => 0.1,
+                    "i_deg" => 5.0,
+                    "raan_deg" => 50.0,
+                    "argp_deg" => 10.0,
+                    "ma_deg" => 20.0,
+                ),
+            ),
+        ],
+    )
+    attach_intercepts!(
+        payload;
+        tof_days_grid=[120],
+        arrive_offset_hours=[0],
+        leo_alt_m=500e3,
+        final_orbits=3.0,
+    )
+    intercept = payload["objects"][1]["intercept"]
+    @test intercept !== nothing
+    @test haskey(intercept, "depart_jd_tdb")
+    @test haskey(intercept, "lambert_polyline_xyz_au")
+    @test haskey(intercept, "capture")
+    @test haskey(intercept["capture"], "capture_dv_kms")
+    @test intercept["capture"]["requested_final_orbits"] == 3.0
+end

--- a/tests/test_julia_backend.py
+++ b/tests/test_julia_backend.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+
+from app.database import upsert_payload
+from app.export import build_viewer_payload
+from app.solar_system import load_missions
+from scripts.plan_intercepts import LOCAL_JULIA, attach_intercepts
+
+
+def test_julia_backend_payload_persists_and_loads(tmp_path):
+    if not os.getenv("JULIA") and not LOCAL_JULIA.exists() and shutil.which("julia") is None:
+        raise AssertionError("Julia backend is required for calculation tests")
+
+    payload = {
+        "schema": "asteroid_intercept_planner/2.0",
+        "objects": [
+            {
+                "des": "TEST-JULIA",
+                "next_ca": {
+                    "fullname": "Synthetic Julia asteroid",
+                    "jd_tdb": 2461200.5,
+                    "cd_tdb": "2026-Jul-09 00:00",
+                    "dist_au": 0.0123,
+                    "diameter_km": 1.0,
+                    "body": "Earth",
+                },
+                "elements": {
+                    "epoch_jd_tdb": 2461000.5,
+                    "a_AU": 1.2,
+                    "e": 0.1,
+                    "i_deg": 5.0,
+                    "raan_deg": 50.0,
+                    "argp_deg": 10.0,
+                    "ma_deg": 20.0,
+                },
+            }
+        ],
+    }
+
+    result = attach_intercepts(
+        payload,
+        tof_days_grid=[120],
+        arrive_offset_hours=[0],
+        leo_alt_m=500e3,
+        final_orbits=3.0,
+    )
+    intercept = result["objects"][0]["intercept"]
+    assert intercept is not None
+    for key in (
+        "depart_jd_tdb",
+        "arrive_jd_tdb",
+        "tof_days",
+        "dv_depart_kms",
+        "dv_arrive_kms",
+        "dv_sum_mps",
+        "c3_km2_s2",
+        "vinf_kms",
+        "leo_dv_kms",
+        "lambert_polyline_xyz_au",
+    ):
+        assert key in intercept
+    assert intercept["capture"]["model"] == "density-sphere-v1"
+    assert intercept["capture"]["capture_dv_kms"] >= 0.0
+    assert intercept["capture"]["requested_final_orbits"] == 3.0
+    assert intercept["capture"]["orbit_polyline_heliocentric_au"]
+
+    database = tmp_path / "asteroids.db"
+    assert upsert_payload(result, database)["plans"] == 1
+    exported = build_viewer_payload(database)
+    exported_intercept = exported["objects"][0]["intercept"]
+    assert exported_intercept["capture"]["model"] == "density-sphere-v1"
+
+    viewer_payload = tmp_path / "viewer.json"
+    viewer_payload.write_text(json.dumps(exported), encoding="utf-8")
+    missions = load_missions(viewer_payload)
+    assert missions[0].capture["model"] == "density-sphere-v1"
+    assert missions[0].final_orbit_polyline_au is not None
+    assert missions[0].capture_duration_days > 0.0
+    assert missions[0].total_duration_days > missions[0].tof_days


### PR DESCRIPTION
## What changed
- Added a Julia calculation backend for Lambert transfer planning and asteroid capture/final-orbit estimates.
- Added density-sphere capture metrics, configurable post-capture orbit count, database/export support, and viewer animation through the capture-orbit phase.
- Added Julia and Python integration tests plus CI setup for the Julia backend.

## Why
The mission viewer now needs to validate and visualize the spacecraft after intercept for a configured number of asteroid orbits, rather than stopping at the intercept point.

## Validation
- `JULIA_DEPOT_PATH=/Users/matthewcranny/Documents/GitHub/neo-updater/.local/julia_depot /Users/matthewcranny/Documents/GitHub/neo-updater/.local/julia/1.12.6/bin/julia --project=. -e 'using Pkg; Pkg.test()'`
- `PYTHONPATH=/private/tmp/neo-updater-julia-capture JULIA=/Users/matthewcranny/Documents/GitHub/neo-updater/.local/julia/1.12.6/bin/julia JULIA_DEPOT_PATH=/Users/matthewcranny/Documents/GitHub/neo-updater/.local/julia_depot /Users/matthewcranny/Documents/GitHub/neo-updater/.venv/bin/python -m pytest`
- `/Users/matthewcranny/Documents/GitHub/neo-updater/.venv/bin/ruff check app scripts/orbital.py scripts/ephem_earth.py scripts/hud_metrics.py scripts/plan_intercepts.py scripts/sbdb_client.py tests run.py`
- `git diff --check`